### PR TITLE
feat: abstract tool from just obsidian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Project-specific binary
 docs2obsidian
+pkm-sync
 
 # Test binary, built with `go test -c`
 *.test
@@ -68,4 +69,7 @@ config/
 *.zip
 *.rar
 .serena/
+
+# Exported files
+exported/
 exported-docs/

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/api/calendar/v3"
 
-	"docs2obsidian/internal/auth"
-	internalcalendar "docs2obsidian/internal/calendar"
-	"docs2obsidian/internal/drive"
-	"docs2obsidian/pkg/models"
+	"pkm-sync/internal/sources/google/auth"
+	internalcalendar "pkm-sync/internal/sources/google/calendar"
+	"pkm-sync/internal/sources/google/drive"
+	"pkm-sync/pkg/models"
 )
 
 var calendarCmd = &cobra.Command{
@@ -26,12 +26,12 @@ By default, shows events from the beginning of the current week to the end of to
 Supports flexible date formats including ISO 8601 dates and relative dates like 'today', 'tomorrow', 'yesterday'.
 
 Examples:
-  docs2obsidian calendar                           # Current week to today
-  docs2obsidian calendar --start today            # Today only  
-  docs2obsidian calendar --start 2025-01-01 --end 2025-01-31
-  docs2obsidian calendar --include-details        # Show meeting URLs, attendees, etc.
-  docs2obsidian calendar --export-docs            # Export attached Google Docs to markdown
-  docs2obsidian calendar --format json            # Output as JSON`,
+  pkm-sync calendar                           # Current week to today
+  pkm-sync calendar --start today            # Today only  
+  pkm-sync calendar --start 2025-01-01 --end 2025-01-31
+  pkm-sync calendar --include-details        # Show meeting URLs, attendees, etc.
+  pkm-sync calendar --export-docs            # Export attached Google Docs to markdown
+  pkm-sync calendar --format json            # Output as JSON`,
 	RunE: runCalendarCommand,
 }
 // Calendar command flags

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"docs2obsidian/internal/auth"
-	"docs2obsidian/internal/calendar"
-	"docs2obsidian/internal/drive"
+	"pkm-sync/internal/sources/google/auth"
+	"pkm-sync/internal/sources/google/calendar"
+	"pkm-sync/internal/sources/google/drive"
 )
 
 var (

--- a/cmd/legacy.go
+++ b/cmd/legacy.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Legacy command compatibility note
+func addLegacyNote(cmd *cobra.Command) {
+	originalRunE := cmd.RunE
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		fmt.Println("NOTE: This is a legacy command. Consider using:")
+		fmt.Printf("  pkm-sync sync --source google --target obsidian --output %s\n", outputDir)
+		fmt.Println()
+		
+		if originalRunE != nil {
+			return originalRunE(c, args)
+		}
+		return nil
+	}
+}
+
+// initLegacyCommands wraps existing commands with legacy compatibility notes
+func initLegacyCommands() {
+	// Add legacy note to existing calendar command
+	if calendarCmd != nil {
+		addLegacyNote(calendarCmd)
+	}
+	
+	// Add legacy note to existing export command
+	if exportCmd != nil {
+		addLegacyNote(exportCmd)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"docs2obsidian/internal/config"
+	"pkm-sync/internal/config"
 )
 
 var (
@@ -15,10 +15,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "docs2obsidian",
-	Short: "A tool to integrate Google Calendar and Drive with Obsidian",
-	Long: `docs2obsidian integrates Google Calendar and Google Drive with your Obsidian notes system.
-It uses OAuth 2.0 for authentication and can fetch calendar events and shared documents.`,
+	Use:   "pkm-sync",
+	Short: "Synchronize data between various sources and PKM systems",
+	Long: `pkm-sync integrates data sources (Google Calendar, Slack, etc.) 
+with Personal Knowledge Management systems (Obsidian, Logseq, etc.).`,
 }
 
 func init() {
@@ -33,6 +33,9 @@ func init() {
 			config.SetCustomConfigDir(configDir)
 		}
 	}
+	
+	// Initialize legacy command compatibility
+	initLegacyCommands()
 }
 
 func Execute() {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"docs2obsidian/internal/auth"
-	"docs2obsidian/internal/calendar"
-	"docs2obsidian/internal/config"
-	"docs2obsidian/internal/drive"
+	"pkm-sync/internal/sources/google/auth"
+	"pkm-sync/internal/sources/google/calendar"
+	"pkm-sync/internal/config"
+	"pkm-sync/internal/sources/google/drive"
 )
 
 var setupCmd = &cobra.Command{
@@ -51,7 +51,7 @@ func runSetupCommand(cmd *cobra.Command, args []string) error {
 		fmt.Printf("6. Download the credentials and save as 'credentials.json' in: %s\n", defaultPath)
 		fmt.Println()
 		fmt.Println("Alternatively, use a custom path with:")
-		fmt.Println("  docs2obsidian --credentials /path/to/credentials.json setup")
+		fmt.Println("  pkm-sync --credentials /path/to/credentials.json setup")
 		
 		return fmt.Errorf("credentials.json file not found")
 	}
@@ -134,8 +134,8 @@ func runSetupCommand(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Println("All authentication checks passed!")
 	fmt.Println("You can now run:")
-	fmt.Println("  - 'docs2obsidian calendar' to list your events")
-	fmt.Println("  - 'docs2obsidian export' to export Google Docs from calendar events")
+	fmt.Println("  - 'pkm-sync calendar' to list your events")
+	fmt.Println("  - 'pkm-sync export' to export Google Docs from calendar events")
 	
 	return nil
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"pkm-sync/internal/sources/google"
+	"pkm-sync/internal/sync"
+	"pkm-sync/internal/targets/logseq"
+	"pkm-sync/internal/targets/obsidian"
+	"pkm-sync/pkg/interfaces"
+)
+
+var (
+	sourceName string
+	targetName string
+	outputDir  string
+	since      string
+	dryRun     bool
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync data from source to target",
+	Long: `Sync data from a source (google, slack, etc.) to a PKM target (obsidian, logseq, etc.)
+    
+Examples:
+  pkm-sync sync --source google --target obsidian --output ./vault
+  pkm-sync sync --source google --target logseq --output ./graph --since 7d
+  pkm-sync sync --source google --target obsidian --dry-run`,
+	RunE: runSyncCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(syncCmd)
+
+	syncCmd.Flags().StringVar(&sourceName, "source", "google", "Data source (google)")
+	syncCmd.Flags().StringVar(&targetName, "target", "obsidian", "PKM target (obsidian, logseq)")
+	syncCmd.Flags().StringVarP(&outputDir, "output", "o", "./exported", "Output directory")
+	syncCmd.Flags().StringVar(&since, "since", "7d", "Sync items since (7d, 2006-01-02, today)")
+	syncCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be synced without making changes")
+}
+
+func runSyncCommand(cmd *cobra.Command, args []string) error {
+	// Parse since parameter
+	sinceTime, err := parseSinceTime(since)
+	if err != nil {
+		return fmt.Errorf("invalid since parameter: %w", err)
+	}
+
+	// Create source
+	source, err := createSource(sourceName)
+	if err != nil {
+		return fmt.Errorf("failed to create source: %w", err)
+	}
+
+	// Create target
+	target, err := createTarget(targetName)
+	if err != nil {
+		return fmt.Errorf("failed to create target: %w", err)
+	}
+
+	// Create syncer
+	syncer := sync.NewSyncer()
+
+	// Sync
+	options := interfaces.SyncOptions{
+		Since:     sinceTime,
+		OutputDir: outputDir,
+		DryRun:    dryRun,
+	}
+
+	return syncer.Sync(source, target, options)
+}
+
+func createSource(name string) (interfaces.Source, error) {
+	switch name {
+	case "google":
+		source := google.NewGoogleSource()
+		if err := source.Configure(nil); err != nil {
+			return nil, err
+		}
+		return source, nil
+	default:
+		return nil, fmt.Errorf("unknown source: %s", name)
+	}
+}
+
+func createTarget(name string) (interfaces.Target, error) {
+	switch name {
+	case "obsidian":
+		target := obsidian.NewObsidianTarget()
+		if err := target.Configure(nil); err != nil {
+			return nil, err
+		}
+		return target, nil
+	case "logseq":
+		target := logseq.NewLogseqTarget()
+		if err := target.Configure(nil); err != nil {
+			return nil, err
+		}
+		return target, nil
+	default:
+		return nil, fmt.Errorf("unknown target: %s", name)
+	}
+}
+
+func parseSinceTime(since string) (time.Time, error) {
+	now := time.Now()
+
+	switch since {
+	case "today":
+		return now.Truncate(24 * time.Hour), nil
+	case "yesterday":
+		return now.Add(-24 * time.Hour).Truncate(24 * time.Hour), nil
+	}
+
+	// Try relative duration (7d, 2h, etc.)
+	// Go's ParseDuration doesn't handle "d" for days, so convert first
+	if strings.HasSuffix(since, "d") {
+		daysStr := strings.TrimSuffix(since, "d")
+		if days, err := time.ParseDuration(daysStr + "h"); err == nil {
+			return now.Add(-days * 24), nil
+		}
+	}
+	
+	if duration, err := time.ParseDuration(since); err == nil {
+		return now.Add(-duration), nil
+	}
+
+	// Try absolute date
+	if t, err := time.Parse("2006-01-02", since); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("unable to parse since time: %s", since)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module docs2obsidian
+module pkm-sync
 
 go 1.24.4
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -33,11 +33,11 @@ func GetConfigDir() (string, error) {
 	var configDir string
 	switch runtime.GOOS {
 	case "windows":
-		configDir = filepath.Join(homeDir, "AppData", "Roaming", "docs2obsidian")
+		configDir = filepath.Join(homeDir, "AppData", "Roaming", "pkm-sync")
 	case "darwin":
-		configDir = filepath.Join(homeDir, ".config", "docs2obsidian")
+		configDir = filepath.Join(homeDir, ".config", "pkm-sync")
 	default:
-		configDir = filepath.Join(homeDir, ".config", "docs2obsidian")
+		configDir = filepath.Join(homeDir, ".config", "pkm-sync")
 	}
 
 	if err := os.MkdirAll(configDir, 0755); err != nil {
@@ -98,11 +98,15 @@ func getCredentialSearchPaths() []string {
 	
 	switch runtime.GOOS {
 	case "windows":
-		paths = append(paths, filepath.Join(homeDir, "AppData", "Roaming", "docs2obsidian", "credentials.json"))
+		paths = append(paths, filepath.Join(homeDir, "AppData", "Roaming", "pkm-sync", "credentials.json"))
 	case "darwin":
+		paths = append(paths, filepath.Join(homeDir, ".config", "pkm-sync", "credentials.json"))
+		paths = append(paths, filepath.Join(homeDir, "Library", "Application Support", "pkm-sync", "credentials.json"))
+		// Backward compatibility with old paths
 		paths = append(paths, filepath.Join(homeDir, ".config", "docs2obsidian", "credentials.json"))
 		paths = append(paths, filepath.Join(homeDir, "Library", "Application Support", "docs2obsidian", "credentials.json"))
 	default:
+		paths = append(paths, filepath.Join(homeDir, ".config", "pkm-sync", "credentials.json"))
 		paths = append(paths, filepath.Join(homeDir, ".config", "docs2obsidian", "credentials.json"))
 	}
 	

--- a/internal/sources/google/auth/auth.go
+++ b/internal/sources/google/auth/auth.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/drive/v3"
 
-	"docs2obsidian/internal/config"
+	"pkm-sync/internal/config"
 )
 
 func GetClient() (*http.Client, error) {

--- a/internal/sources/google/calendar/service.go
+++ b/internal/sources/google/calendar/service.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 
-	"docs2obsidian/pkg/models"
+	"pkm-sync/pkg/models"
 )
 
 type Service struct {

--- a/internal/sources/google/drive/service.go
+++ b/internal/sources/google/drive/service.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"docs2obsidian/pkg/models"
+	"pkm-sync/pkg/models"
 	"google.golang.org/api/drive/v3"
 )
 

--- a/internal/sources/google/source.go
+++ b/internal/sources/google/source.go
@@ -1,0 +1,73 @@
+package google
+
+import (
+	"net/http"
+	"time"
+
+	"pkm-sync/internal/sources/google/auth"
+	"pkm-sync/internal/sources/google/calendar"
+	"pkm-sync/internal/sources/google/drive"
+	"pkm-sync/pkg/models"
+)
+
+type GoogleSource struct {
+	calendarService *calendar.Service
+	driveService    *drive.Service
+	httpClient      *http.Client
+}
+
+func NewGoogleSource() *GoogleSource {
+	return &GoogleSource{}
+}
+
+func (g *GoogleSource) Name() string {
+	return "google"
+}
+
+func (g *GoogleSource) Configure(config map[string]interface{}) error {
+	// Use existing auth logic
+	client, err := auth.GetClient()
+	if err != nil {
+		return err
+	}
+	g.httpClient = client
+
+	// Initialize services using existing code
+	g.calendarService, err = calendar.NewService(client)
+	if err != nil {
+		return err
+	}
+
+	g.driveService, err = drive.NewService(client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *GoogleSource) Fetch(since time.Time, limit int) ([]*models.Item, error) {
+	// Use existing calendar.GetEventsInRange
+	end := time.Now().Add(24 * time.Hour) // Default to next 24 hours
+	events, err := g.calendarService.GetEventsInRange(since, end, int64(limit))
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert events to universal Item format
+	var items []*models.Item
+	for _, event := range events {
+		// Convert to our model first
+		calEvent := g.calendarService.ConvertToModelWithDrive(event, g.driveService)
+		
+		// Then convert to universal Item format
+		item := models.FromCalendarEvent(calEvent)
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+func (g *GoogleSource) SupportsRealtime() bool {
+	return false // Future: implement webhooks
+}

--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -1,0 +1,38 @@
+package sync
+
+import (
+	"fmt"
+
+	"pkm-sync/pkg/interfaces"
+)
+
+type DefaultSyncer struct{}
+
+func NewSyncer() *DefaultSyncer {
+	return &DefaultSyncer{}
+}
+
+func (s *DefaultSyncer) Sync(source interfaces.Source, target interfaces.Target, options interfaces.SyncOptions) error {
+	fmt.Printf("Syncing from %s to %s...\n", source.Name(), target.Name())
+
+	// Fetch items from source
+	items, err := source.Fetch(options.Since, 100) // TODO: make limit configurable
+	if err != nil {
+		return fmt.Errorf("failed to fetch from source: %w", err)
+	}
+
+	fmt.Printf("Found %d items\n", len(items))
+
+	if options.DryRun {
+		fmt.Printf("DRY RUN: Would export %d items to %s\n", len(items), options.OutputDir)
+		return nil
+	}
+
+	// Export to target
+	if err := target.Export(items, options.OutputDir); err != nil {
+		return fmt.Errorf("failed to export to target: %w", err)
+	}
+
+	fmt.Printf("Successfully exported %d items\n", len(items))
+	return nil
+}

--- a/internal/targets/logseq/target.go
+++ b/internal/targets/logseq/target.go
@@ -1,0 +1,157 @@
+package logseq
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"pkm-sync/pkg/models"
+)
+
+type LogseqTarget struct {
+	graphPath   string
+	journalPath string
+	pagesPath   string
+}
+
+func NewLogseqTarget() *LogseqTarget {
+	return &LogseqTarget{}
+}
+
+func (l *LogseqTarget) Name() string {
+	return "logseq"
+}
+
+func (l *LogseqTarget) Configure(config map[string]interface{}) error {
+	if graphPath, ok := config["graph_path"].(string); ok {
+		l.graphPath = graphPath
+		l.journalPath = filepath.Join(graphPath, "journals")
+		l.pagesPath = filepath.Join(graphPath, "pages")
+	}
+	return nil
+}
+
+func (l *LogseqTarget) Export(items []*models.Item, outputDir string) error {
+	// Use flat structure - all files in outputDir
+	for _, item := range items {
+		if err := l.exportItem(item, outputDir); err != nil {
+			return fmt.Errorf("failed to export item %s: %w", item.ID, err)
+		}
+	}
+	return nil
+}
+
+func (l *LogseqTarget) exportItem(item *models.Item, outputDir string) error {
+	filename := l.FormatFilename(item.Title)
+	filePath := filepath.Join(outputDir, filename)
+
+	// Create directory if needed
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
+
+	content := l.formatContent(item)
+	return os.WriteFile(filePath, []byte(content), 0644)
+}
+
+func (l *LogseqTarget) formatContent(item *models.Item) string {
+	var sb strings.Builder
+
+	// Properties block (Logseq-specific)
+	sb.WriteString("- id:: " + item.ID + "\n")
+	sb.WriteString("- source:: " + item.SourceType + "\n")
+	sb.WriteString("- type:: " + item.ItemType + "\n")
+	sb.WriteString("- created:: [[" + item.CreatedAt.Format("Jan 2nd, 2006") + "]]\n")
+
+	// Add custom metadata
+	for key, value := range item.Metadata {
+		sb.WriteString(fmt.Sprintf("- %s:: %v\n", key, value))
+	}
+
+	// Tags
+	if len(item.Tags) > 0 {
+		sb.WriteString("- tags:: ")
+		for i, tag := range item.Tags {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("#" + tag)
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\n")
+
+	// Title as heading
+	sb.WriteString("# " + item.Title + "\n\n")
+
+	// Content
+	if item.Content != "" {
+		sb.WriteString(item.Content)
+		sb.WriteString("\n\n")
+	}
+
+	// Attachments as blocks
+	if len(item.Attachments) > 0 {
+		sb.WriteString("## Attachments\n")
+		for _, attachment := range item.Attachments {
+			sb.WriteString("- [[" + attachment.Name + "]]\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	// Links as blocks
+	if len(item.Links) > 0 {
+		sb.WriteString("## Links\n")
+		for _, link := range item.Links {
+			sb.WriteString("- [" + link.Title + "](" + link.URL + ")\n")
+		}
+	}
+
+	return sb.String()
+}
+
+func (l *LogseqTarget) FormatFilename(title string) string {
+	// Logseq prefers page references format
+	filename := sanitizeFilename(title)
+	return filename + ".md"
+}
+
+func (l *LogseqTarget) GetFileExtension() string {
+	return ".md"
+}
+
+func (l *LogseqTarget) FormatMetadata(metadata map[string]interface{}) string {
+	var sb strings.Builder
+	for key, value := range metadata {
+		sb.WriteString(fmt.Sprintf("- %s:: %v\n", key, value))
+	}
+	return sb.String()
+}
+
+// sanitizeFilename removes or replaces characters that are invalid in filenames
+func sanitizeFilename(filename string) string {
+	replacements := map[string]string{
+		"/":  "-",
+		"\\": "-",
+		":":  "-",
+		"*":  "",
+		"?":  "",
+		"\"": "",
+		"<":  "",
+		">":  "",
+		"|":  "-",
+	}
+
+	for old, new := range replacements {
+		filename = strings.ReplaceAll(filename, old, new)
+	}
+
+	filename = strings.TrimSpace(filename)
+	for strings.Contains(filename, "  ") {
+		filename = strings.ReplaceAll(filename, "  ", " ")
+	}
+
+	return filename
+}

--- a/internal/targets/obsidian/target.go
+++ b/internal/targets/obsidian/target.go
@@ -1,0 +1,153 @@
+package obsidian
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"pkm-sync/pkg/models"
+)
+
+type ObsidianTarget struct {
+	vaultPath        string
+	templateDir      string
+	dailyNotesFormat string
+}
+
+func NewObsidianTarget() *ObsidianTarget {
+	return &ObsidianTarget{
+		dailyNotesFormat: "2006-01-02", // Default: YYYY-MM-DD
+	}
+}
+
+func (o *ObsidianTarget) Name() string {
+	return "obsidian"
+}
+
+func (o *ObsidianTarget) Configure(config map[string]interface{}) error {
+	if vaultPath, ok := config["vault_path"].(string); ok {
+		o.vaultPath = vaultPath
+	}
+	if templateDir, ok := config["template_dir"].(string); ok {
+		o.templateDir = templateDir
+	}
+	if format, ok := config["daily_notes_format"].(string); ok {
+		o.dailyNotesFormat = format
+	}
+	return nil
+}
+
+func (o *ObsidianTarget) Export(items []*models.Item, outputDir string) error {
+	for _, item := range items {
+		if err := o.exportItem(item, outputDir); err != nil {
+			return fmt.Errorf("failed to export item %s: %w", item.ID, err)
+		}
+	}
+	return nil
+}
+
+func (o *ObsidianTarget) exportItem(item *models.Item, outputDir string) error {
+	filename := o.FormatFilename(item.Title)
+	filePath := filepath.Join(outputDir, filename)
+
+	// Create directory if needed
+	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+		return err
+	}
+
+	content := o.formatContent(item)
+	return os.WriteFile(filePath, []byte(content), 0644)
+}
+
+func (o *ObsidianTarget) formatContent(item *models.Item) string {
+	var sb strings.Builder
+
+	// YAML frontmatter
+	sb.WriteString("---\n")
+	sb.WriteString(o.FormatMetadata(item.Metadata))
+	sb.WriteString(fmt.Sprintf("id: %s\n", item.ID))
+	sb.WriteString(fmt.Sprintf("source: %s\n", item.SourceType))
+	sb.WriteString(fmt.Sprintf("type: %s\n", item.ItemType))
+	sb.WriteString(fmt.Sprintf("created: %s\n", item.CreatedAt.Format(time.RFC3339)))
+	if len(item.Tags) > 0 {
+		sb.WriteString("tags:\n")
+		for _, tag := range item.Tags {
+			sb.WriteString(fmt.Sprintf("  - %s\n", tag))
+		}
+	}
+	sb.WriteString("---\n\n")
+
+	// Title
+	sb.WriteString(fmt.Sprintf("# %s\n\n", item.Title))
+
+	// Content
+	if item.Content != "" {
+		sb.WriteString(item.Content)
+		sb.WriteString("\n\n")
+	}
+
+	// Attachments
+	if len(item.Attachments) > 0 {
+		sb.WriteString("## Attachments\n\n")
+		for _, attachment := range item.Attachments {
+			sb.WriteString(fmt.Sprintf("- [[%s]]\n", attachment.Name))
+		}
+		sb.WriteString("\n")
+	}
+
+	// Links
+	if len(item.Links) > 0 {
+		sb.WriteString("## Links\n\n")
+		for _, link := range item.Links {
+			sb.WriteString(fmt.Sprintf("- [%s](%s)\n", link.Title, link.URL))
+		}
+	}
+
+	return sb.String()
+}
+
+func (o *ObsidianTarget) FormatFilename(title string) string {
+	// Use sanitizeFilename logic similar to drive service
+	filename := sanitizeFilename(title)
+	return filename + ".md"
+}
+
+func (o *ObsidianTarget) GetFileExtension() string {
+	return ".md"
+}
+
+func (o *ObsidianTarget) FormatMetadata(metadata map[string]interface{}) string {
+	var sb strings.Builder
+	for key, value := range metadata {
+		sb.WriteString(fmt.Sprintf("%s: %v\n", key, value))
+	}
+	return sb.String()
+}
+
+// sanitizeFilename removes or replaces characters that are invalid in filenames
+func sanitizeFilename(filename string) string {
+	replacements := map[string]string{
+		"/":  "-",
+		"\\": "-",
+		":":  "-",
+		"*":  "",
+		"?":  "",
+		"\"": "",
+		"<":  "",
+		">":  "",
+		"|":  "-",
+	}
+
+	for old, new := range replacements {
+		filename = strings.ReplaceAll(filename, old, new)
+	}
+
+	filename = strings.TrimSpace(filename)
+	for strings.Contains(filename, "  ") {
+		filename = strings.ReplaceAll(filename, "  ", " ")
+	}
+
+	return filename
+}

--- a/pkg/interfaces/interfaces.go
+++ b/pkg/interfaces/interfaces.go
@@ -1,0 +1,36 @@
+package interfaces
+
+import (
+	"time"
+	"pkm-sync/pkg/models"
+)
+
+// Source represents any data source (Google Calendar, Slack, etc.)
+type Source interface {
+	Name() string
+	Configure(config map[string]interface{}) error
+	Fetch(since time.Time, limit int) ([]*models.Item, error)
+	SupportsRealtime() bool
+}
+
+// Target represents any PKM system (Obsidian, Logseq, etc.)
+type Target interface {
+	Name() string
+	Configure(config map[string]interface{}) error
+	Export(items []*models.Item, outputDir string) error
+	FormatFilename(title string) string
+	GetFileExtension() string
+	FormatMetadata(metadata map[string]interface{}) string
+}
+
+// Syncer coordinates between sources and targets
+type Syncer interface {
+	Sync(source Source, target Target, options SyncOptions) error
+}
+
+type SyncOptions struct {
+	Since     time.Time
+	OutputDir string
+	DryRun    bool
+	Overwrite bool
+}

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -1,0 +1,72 @@
+package models
+
+import "time"
+
+// Item represents a universal data item from any source
+type Item struct {
+	ID          string                 `json:"id"`
+	Title       string                 `json:"title"`
+	Content     string                 `json:"content"`
+	SourceType  string                 `json:"source_type"`  // "google_calendar", "slack", etc.
+	ItemType    string                 `json:"item_type"`    // "event", "message", "document", etc.
+	CreatedAt   time.Time              `json:"created_at"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+	Tags        []string               `json:"tags"`
+	Attachments []Attachment           `json:"attachments"`
+	Metadata    map[string]interface{} `json:"metadata"`
+	Links       []Link                 `json:"links"` // URLs, references
+}
+
+type Attachment struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	MimeType  string `json:"mime_type"`
+	URL       string `json:"url"`
+	LocalPath string `json:"local_path,omitempty"`
+}
+
+type Link struct {
+	URL   string `json:"url"`
+	Title string `json:"title"`
+	Type  string `json:"type"` // "meeting_url", "document", "external"
+}
+
+// Migrate from existing CalendarEvent model
+func FromCalendarEvent(event *CalendarEvent) *Item {
+	item := &Item{
+		ID:         event.ID,
+		Title:      event.Summary,
+		Content:    event.Description,
+		SourceType: "google_calendar",
+		ItemType:   "event",
+		CreatedAt:  event.Start, // Using start time as creation time for events
+		UpdatedAt:  event.Start, // Using start time since we don't have modified time in CalendarEvent
+		Metadata: map[string]interface{}{
+			"start_time": event.Start,
+			"end_time":   event.End,
+			"location":   event.Location,
+			"attendees":  event.Attendees,
+		},
+	}
+
+	// Convert Drive attachments
+	for _, doc := range event.AttachedDocs {
+		item.Attachments = append(item.Attachments, Attachment{
+			ID:       doc.ID,
+			Name:     doc.Name,
+			MimeType: doc.MimeType,
+			URL:      doc.WebViewLink,
+		})
+	}
+
+	// Add meeting URL as a link
+	if event.MeetingURL != "" {
+		item.Links = append(item.Links, Link{
+			URL:   event.MeetingURL,
+			Title: "Meeting URL",
+			Type:  "meeting_url",
+		})
+	}
+
+	return item
+}


### PR DESCRIPTION
This tool can be generalized to not just export to obsidian. Since most of the logic here is helpful for fetching various sources of information into personal knowlege management systems, I am proposing a rename while also including export support for logseq.

Co-Authored-By: Claude <noreply@antrhopic.com>
Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED